### PR TITLE
Update Link.php to support sites behind Cloudflare

### DIFF
--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -197,7 +197,9 @@ class Link extends Model
      */
     public function getIP()
     {
-        if (! empty($_SERVER['HTTP_CLIENT_IP'])) {   //check ip from share internet
+        if (! empty($_SERVER['HTTP_CF_CONNECTING_IP'])) {   //check ip from cloudflare
+          $ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
+        } elseif (! empty($_SERVER['HTTP_CLIENT_IP'])) {   //check ip from share internet
           $ip = $_SERVER['HTTP_CLIENT_IP'];
         } elseif (! empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {   //to check ip is pass from proxy
           $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];


### PR DESCRIPTION
Sites behind Cloudflare can access the IP address of the visitor by looking for a HTTP_CF_CONNECTING_IP header. 

Cloudflare does set the HTTP_X_FORWARDED_FOR header, but if the visitor is behind a Proxy themselves, it starts getting weird and hard to parse. The HTTP_CF_CONNECTING_IP header is the easiest way. 

```
If there is an "X-Forwarded-For" header present in the request, CloudFlare will append the client's IP to its value, as the last in the list.

"X-Forwarded-For: A.B.C.D[,X.X.X.X,Y.Y.Y.Y,]"

where A.B.C.D is the client's IP address, also known as the original visitor IP address. X.X.X.X and Y.Y.Y.Y in this example are IP addresses along the route in the header value.
```

From https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-CloudFlare-handle-HTTP-Request-headers-